### PR TITLE
feat[#87]: 모달 내용 페이지에서 작성할 수 있게

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -14,7 +14,7 @@ function Modal({ setViewPayment, children }: props) {
   return (
     <div className="fixed justify-normal top-0 left-50 w-[448px] h-full bg-black bg-opacity-20 overflow-hidden">
       <button
-        className="absolute top-3 right-6 w-4 h-4 text-3xl text-neutral-50 cursor-pointer"
+        className="fixed top-16 right-40 w-4 h-4 text-3xl text-neutral-50 cursor-pointer"
         onClick={() => closeModal()}
       >
         X

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,30 +1,18 @@
-import Tag from './Tag';
-import Button from './Button';
-import Counter from './Counter';
-import { useState } from 'react';
-
 interface props {
   setViewPayment: React.Dispatch<React.SetStateAction<boolean>>;
+  children: React.ReactNode;
 }
 
 // 부모 컴포넌트에 modal 여부를 결정하는 state, Modal 컴포넌트에 setter를 전달해야 합니다.
 // ex) const [viewPayment, setViewPayment] = useState(false);
 // {viewPayment && <Modal setViewPayment={setViewPayment} />}
-function Modal({ setViewPayment }: props) {
+function Modal({ setViewPayment, children }: props) {
   const closeModal = () => {
     setViewPayment(false);
   };
 
-  // counter 상태 관리
-  const [num, setNum] = useState(0);
-
-  // modal 상태 관리
-  // 임시로 1, 2, 3으로 지정했고 추후에 상세페이지에서 버튼 클릭했을 때
-  // 정보를 받아서 모달 콘텐츠가 알맞게 나오게 하면 될 것 같습니다.
-  const [content] = useState(2);
-
   return (
-    <div className="absolute justify-normal top-0 left-0 w-full h-full bg-black bg-opacity-20 overflow-hidden">
+    <div className="fixed justify-normal top-0 left-50 w-[448px] h-full bg-black bg-opacity-20 overflow-hidden">
       <button
         className="absolute top-3 right-6 w-4 h-4 text-3xl text-neutral-50 cursor-pointer"
         onClick={() => closeModal()}
@@ -34,72 +22,7 @@ function Modal({ setViewPayment }: props) {
       {/* <div className="absolute top-[84%] left-2/4 w-[400px] h-1/3 p-5 text-center bg-white rounded shadow transform -translate-x-1/2 -translate-y-1/2 animate-revealDown"> */}
       <div className="absolute bottom-0 left-1/2 w-[400px] p-5 text-center bg-white rounded shadow transform -translate-x-1/2 animate-revealDown">
         {/* 아래부터 모달 내용 */}
-        {/* content에 입력된 정보에 따라서 modal 내용이 변경될 수 있게 */}
-        {/* content === 1 : 공구 */}
-        {content === 1 && (
-          <div>
-            <h2 className="mb-5 font-semibold">공구 장소, 시간을 확인하세요</h2>
-            <div className="flex flex-col gap-4 mb-8">
-              <Tag tagName="location">공릉2동 주공아파트 3단지 놀이터 앞</Tag>
-              <Tag tagName="time">10:00</Tag>
-              <Tag tagName="people">2/10</Tag>
-            </div>
-            <Button bg="main" color="white" height="40px" text="text-sm">
-              공구하기
-            </Button>
-          </div>
-        )}
-        {/* content === 2 : 구매 */}
-        {content === 2 && (
-          <div>
-            <h2 className="mb-5 font-semibold">
-              거래 가격, 장소, 개수를 확인하세요
-            </h2>
-            <div className="flex flex-col gap-4 mb-8">
-              <Tag tagName="cash">총가격 : 9,000원</Tag>
-              <Tag tagName="location">공릉2동 주공아파트 3단지 놀이터 앞</Tag>
-              <Tag tagName="item">
-                구매 개수 <Counter num={num} setNum={setNum}></Counter>
-              </Tag>
-              <Tag tagName="time">10:00</Tag>
-            </div>
-            <Button bg="main" color="white" height="40px" text="text-sm">
-              구매하기
-            </Button>
-          </div>
-        )}
-        {/* 구매자 늘어나면 스크롤 넣어야 될것 같습니다. */}
-        {/* content === 3 : 구매자 조회 */}
-        {content === 3 && (
-          <div>
-            <h2 className="mb-3">구매 신청자 목록</h2>
-            <div className="flex flex-col gap-5">
-              <Tag tagName="people">2/10</Tag>
-              <ul className="mr-7 flex flex-col gap-3">
-                <li className="flex items-center gap-3">
-                  <img src="images/logos/default_image.svg" />
-                  <p className="grow text-left">장유진</p>
-                  <Tag tagName="item">1/6</Tag>
-                </li>
-                <li className="flex items-center gap-3">
-                  <img src="images/logos/default_image.svg" />
-                  <p className="grow text-left">이선재</p>
-                  <Tag tagName="item">1/6</Tag>
-                </li>
-                <li className="flex items-center gap-3">
-                  <img src="images/logos/default_image.svg" />
-                  <p className="grow text-left">이현종</p>
-                  <Tag tagName="item">1/6</Tag>
-                </li>
-                <li className="flex items-center gap-3">
-                  <img src="images/logos/default_image.svg" />
-                  <p className="grow text-left">김건우</p>
-                  <Tag tagName="item">1/6</Tag>
-                </li>
-              </ul>
-            </div>
-          </div>
-        )}
+        {children}
       </div>
     </div>
   );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,31 +1,18 @@
-import { useState } from 'react';
-
-import Tag from './Tag';
-import Button from './Button';
-import Counter from './Counter';
-
 interface props {
   setViewPayment: React.Dispatch<React.SetStateAction<boolean>>;
+  children: React.ReactNode;
 }
 
 // 부모 컴포넌트에 modal 여부를 결정하는 state, Modal 컴포넌트에 setter를 전달해야 합니다.
 // ex) const [viewPayment, setViewPayment] = useState(false);
 // {viewPayment && <Modal setViewPayment={setViewPayment} />}
-function Modal({ setViewPayment }: props) {
+function Modal({ setViewPayment, children }: props) {
   const closeModal = () => {
     setViewPayment(false);
   };
 
-  // counter 상태 관리
-  const [num, setNum] = useState(0);
-
-  // modal 상태 관리
-  // 임시로 1, 2, 3으로 지정했고 추후에 상세페이지에서 버튼 클릭했을 때
-  // 정보를 받아서 모달 콘텐츠가 알맞게 나오게 하면 될 것 같습니다.
-  const [content] = useState(2);
-
   return (
-    <div className="absolute justify-normal top-0 left-0 w-full h-full bg-black bg-opacity-20 overflow-hidden">
+    <div className="fixed justify-normal top-0 left-50 w-[448px] h-full bg-black bg-opacity-20 overflow-hidden">
       <button
         className="absolute top-3 right-6 w-4 h-4 text-3xl text-neutral-50 cursor-pointer"
         onClick={() => closeModal()}
@@ -35,72 +22,7 @@ function Modal({ setViewPayment }: props) {
       {/* <div className="absolute top-[84%] left-2/4 w-[400px] h-1/3 p-5 text-center bg-white rounded shadow transform -translate-x-1/2 -translate-y-1/2 animate-revealDown"> */}
       <div className="absolute bottom-0 left-1/2 w-[400px] p-5 text-center bg-white rounded shadow transform -translate-x-1/2 animate-revealDown">
         {/* 아래부터 모달 내용 */}
-        {/* content에 입력된 정보에 따라서 modal 내용이 변경될 수 있게 */}
-        {/* content === 1 : 공구 */}
-        {content === 1 && (
-          <div>
-            <h2 className="mb-5 font-semibold">공구 장소, 시간을 확인하세요</h2>
-            <div className="flex flex-col gap-4 mb-8">
-              <Tag tagName="location">공릉2동 주공아파트 3단지 놀이터 앞</Tag>
-              <Tag tagName="time">10:00</Tag>
-              <Tag tagName="people">2/10</Tag>
-            </div>
-            <Button bg="main" color="white" height="40px" text="text-sm">
-              공구하기
-            </Button>
-          </div>
-        )}
-        {/* content === 2 : 구매 */}
-        {content === 2 && (
-          <div>
-            <h2 className="mb-5 font-semibold">
-              거래 가격, 장소, 개수를 확인하세요
-            </h2>
-            <div className="flex flex-col gap-4 mb-8">
-              <Tag tagName="cash">총가격 : 9,000원</Tag>
-              <Tag tagName="location">공릉2동 주공아파트 3단지 놀이터 앞</Tag>
-              <Tag tagName="item">
-                구매 개수 <Counter num={num} setNum={setNum}></Counter>
-              </Tag>
-              <Tag tagName="time">10:00</Tag>
-            </div>
-            <Button bg="main" color="white" height="40px" text="text-sm">
-              구매하기
-            </Button>
-          </div>
-        )}
-        {/* 구매자 늘어나면 스크롤 넣어야 될것 같습니다. */}
-        {/* content === 3 : 구매자 조회 */}
-        {content === 3 && (
-          <div>
-            <h2 className="mb-3">구매 신청자 목록</h2>
-            <div className="flex flex-col gap-5">
-              <Tag tagName="people">2/10</Tag>
-              <ul className="mr-7 flex flex-col gap-3">
-                <li className="flex items-center gap-3">
-                  <img src="images/logos/default_image.svg" />
-                  <p className="grow text-left">장유진</p>
-                  <Tag tagName="item">1/6</Tag>
-                </li>
-                <li className="flex items-center gap-3">
-                  <img src="images/logos/default_image.svg" />
-                  <p className="grow text-left">이선재</p>
-                  <Tag tagName="item">1/6</Tag>
-                </li>
-                <li className="flex items-center gap-3">
-                  <img src="images/logos/default_image.svg" />
-                  <p className="grow text-left">이현종</p>
-                  <Tag tagName="item">1/6</Tag>
-                </li>
-                <li className="flex items-center gap-3">
-                  <img src="images/logos/default_image.svg" />
-                  <p className="grow text-left">김건우</p>
-                  <Tag tagName="item">1/6</Tag>
-                </li>
-              </ul>
-            </div>
-          </div>
-        )}
+        {children}
       </div>
     </div>
   );

--- a/src/pages/detail/detail.tsx
+++ b/src/pages/detail/detail.tsx
@@ -11,6 +11,8 @@ import member from '/images/member.svg';
 import Comment from '../../components/Comment';
 import CommentAdd from '../../components/CommentAdd';
 import Button from '../../components/Button';
+import Modal from '../../components/Modal';
+import Tag from '../../components/Tag';
 
 const Detail = () => {
   // 공구인지, 판매하기인지에 따라 멘트 구별
@@ -20,6 +22,21 @@ const Detail = () => {
   // 관심 및 댓글의 수
   const [interest, setInterest] = useState(7);
   const [commentNum, setCommentNum] = useState(5);
+
+  const [viewPayment, setViewPayment] = useState(false);
+
+  // counter 상태 관리
+  const [num, setNum] = useState(0);
+
+  // modal 상태 관리
+  // 임시로 1, 2, 3으로 지정했고 추후에 상세페이지에서 버튼 클릭했을 때
+  // 정보를 받아서 모달 콘텐츠가 알맞게 나오게 하면 될 것 같습니다.
+  const [content, setContent] = useState(2);
+
+  const handleModal = () => {
+    setViewPayment(true);
+  };
+
   return (
     <div className="mb-[60px] h-screen">
       <Header>
@@ -35,6 +52,7 @@ const Detail = () => {
       </Header>
       {/* 이미지 슬라이드 */}
       <ImageSlideDetail />
+
       <div className="main">
         <div className="board-info">
           <div className="board-title flex mt-4 pl-7 pr-6">
@@ -87,10 +105,90 @@ const Detail = () => {
           </div>
           <Comment />
           <CommentAdd />
-          <Button height="40px" text="text-sm" bg="main" color="white">
+          <Button
+            height="40px"
+            text="text-sm"
+            bg="main"
+            color="white"
+            onClick={() => handleModal()}
+          >
             공구하기
           </Button>
         </div>
+        {viewPayment && (
+          <Modal setViewPayment={setViewPayment}>
+            {/* content에 입력된 정보에 따라서 modal 내용이 변경될 수 있게 */}
+            {/* content === 1 : 공구 */}
+
+            <div>
+              <h2 className="mb-5 font-semibold">
+                공구 장소, 시간을 확인하세요
+              </h2>
+              <div className="flex flex-col gap-4 mb-8">
+                <Tag tagName="location">공릉2동 주공아파트 3단지 놀이터 앞</Tag>
+                <Tag tagName="time">10:00</Tag>
+                <Tag tagName="people">2/10</Tag>
+              </div>
+              <Button bg="main" color="white" height="40px" text="text-sm">
+                공구하기
+              </Button>
+            </div>
+
+            {/* content === 2 : 구매 */}
+            {/* {content === 2 && (
+                <div>
+                  <h2 className="mb-5 font-semibold">
+                    거래 가격, 장소, 개수를 확인하세요
+                  </h2>
+                  <div className="flex flex-col gap-4 mb-8">
+                    <Tag tagName="cash">총가격 : 9,000원</Tag>
+                    <Tag tagName="location">
+                      공릉2동 주공아파트 3단지 놀이터 앞
+                    </Tag>
+                    <Tag tagName="item">
+                      구매 개수 <Counter num={num} setNum={setNum}></Counter>
+                    </Tag>
+                    <Tag tagName="time">10:00</Tag>
+                  </div>
+                  <Button bg="main" color="white" height="40px" text="text-sm">
+                    구매하기
+                  </Button>
+                </div>
+              )} */}
+            {/* 구매자 늘어나면 스크롤 넣어야 될것 같습니다. */}
+            {/* content === 3 : 구매자 조회 */}
+            {/* {content === 3 && (
+                <div>
+                  <h2 className="mb-3">구매 신청자 목록</h2>
+                  <div className="flex flex-col gap-5">
+                    <Tag tagName="people">2/10</Tag>
+                    <ul className="mr-7 flex flex-col gap-3">
+                      <li className="flex items-center gap-3">
+                        <img src="images/logos/default_image.svg" />
+                        <p className="grow text-left">장유진</p>
+                        <Tag tagName="item">1/6</Tag>
+                      </li>
+                      <li className="flex items-center gap-3">
+                        <img src="images/logos/default_image.svg" />
+                        <p className="grow text-left">이선재</p>
+                        <Tag tagName="item">1/6</Tag>
+                      </li>
+                      <li className="flex items-center gap-3">
+                        <img src="images/logos/default_image.svg" />
+                        <p className="grow text-left">이현종</p>
+                        <Tag tagName="item">1/6</Tag>
+                      </li>
+                      <li className="flex items-center gap-3">
+                        <img src="images/logos/default_image.svg" />
+                        <p className="grow text-left">김건우</p>
+                        <Tag tagName="item">1/6</Tag>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              )} */}
+          </Modal>
+        )}
       </div>
     </div>
   );

--- a/src/pages/detail/detail.tsx
+++ b/src/pages/detail/detail.tsx
@@ -28,14 +28,15 @@ const Detail = () => {
   const [viewPayment, setViewPayment] = useState(false);
 
   // counter 상태 관리
-  const [num, setNum] = useState(0);
+  // const [num, setNum] = useState(0);
 
   // modal 상태 관리
-  // 임시로 1, 2, 3으로 지정했고 추후에 상세페이지에서 버튼 클릭했을 때
-  // 정보를 받아서 모달 콘텐츠가 알맞게 나오게 하면 될 것 같습니다.
-  const [content, setContent] = useState(2);
+  // 상세페이지에서 버튼 클릭했을 때 정보를 받아서 모달 콘텐츠가 알맞게 나오게 하면 될 것 같습니다.
+  // 임시로 공구하기, 구매자 확인만 동작하게 만들었습니다.
+  const [content, setContent] = useState(typeBuy);
 
-  const handleModal = () => {
+  const handleModal = (contentType: string) => {
+    setContent(contentType);
     setViewPayment(true);
   };
 
@@ -113,7 +114,8 @@ const Detail = () => {
             text="text-sm"
             bg="main"
             color="white"
-            onClick={() => handleModal()}
+            // handleModal 변수에 따라서 모달 내용 변경되게
+            onClick={() => handleModal(typeBuy)}
           >
             공구하기
           </Button>
@@ -121,24 +123,24 @@ const Detail = () => {
         {viewPayment && (
           <Modal setViewPayment={setViewPayment}>
             {/* content에 입력된 정보에 따라서 modal 내용이 변경될 수 있게 */}
-            {/* content === 1 : 공구 */}
-
-            <div>
-              <h2 className="mb-5 font-semibold">
-                공구 장소, 시간을 확인하세요
-              </h2>
-              <div className="flex flex-col gap-4 mb-8">
-                <Tag tagName="location">공릉2동 주공아파트 3단지 놀이터 앞</Tag>
-                <Tag tagName="time">10:00</Tag>
-                <Tag tagName="people">2/10</Tag>
+            {content === typeBuy && (
+              <div>
+                <h2 className="mb-5 font-semibold">
+                  공구 장소, 시간을 확인하세요
+                </h2>
+                <div className="flex flex-col gap-4 mb-8">
+                  <Tag tagName="location">
+                    공릉2동 주공아파트 3단지 놀이터 앞
+                  </Tag>
+                  <Tag tagName="time">10:00</Tag>
+                  <Tag tagName="people">2/10</Tag>
+                </div>
+                <Button bg="main" color="white" height="40px" text="text-sm">
+                  공구하기
+                </Button>
               </div>
-              <Button bg="main" color="white" height="40px" text="text-sm">
-                공구하기
-              </Button>
-            </div>
-
-            {/* content === 2 : 구매 */}
-            {/* {content === 2 && (
+            )}
+            {/* {content === ??? && (
                 <div>
                   <h2 className="mb-5 font-semibold">
                     거래 가격, 장소, 개수를 확인하세요
@@ -159,37 +161,36 @@ const Detail = () => {
                 </div>
               )} */}
             {/* 구매자 늘어나면 스크롤 넣어야 될것 같습니다. */}
-            {/* content === 3 : 구매자 조회 */}
-            {/* {content === 3 && (
-                <div>
-                  <h2 className="mb-3">구매 신청자 목록</h2>
-                  <div className="flex flex-col gap-5">
-                    <Tag tagName="people">2/10</Tag>
-                    <ul className="mr-7 flex flex-col gap-3">
-                      <li className="flex items-center gap-3">
-                        <img src="images/logos/default_image.svg" />
-                        <p className="grow text-left">장유진</p>
-                        <Tag tagName="item">1/6</Tag>
-                      </li>
-                      <li className="flex items-center gap-3">
-                        <img src="images/logos/default_image.svg" />
-                        <p className="grow text-left">이선재</p>
-                        <Tag tagName="item">1/6</Tag>
-                      </li>
-                      <li className="flex items-center gap-3">
-                        <img src="images/logos/default_image.svg" />
-                        <p className="grow text-left">이현종</p>
-                        <Tag tagName="item">1/6</Tag>
-                      </li>
-                      <li className="flex items-center gap-3">
-                        <img src="images/logos/default_image.svg" />
-                        <p className="grow text-left">김건우</p>
-                        <Tag tagName="item">1/6</Tag>
-                      </li>
-                    </ul>
-                  </div>
+            {content === typeSell && (
+              <div>
+                <h2 className="mb-3">구매 신청자 목록</h2>
+                <div className="flex flex-col gap-5">
+                  <Tag tagName="people">2/10</Tag>
+                  <ul className="mr-7 flex flex-col gap-3">
+                    <li className="flex items-center gap-3">
+                      <img src="images/logos/default_image.svg" />
+                      <p className="grow text-left">장유진</p>
+                      <Tag tagName="item">1/6</Tag>
+                    </li>
+                    <li className="flex items-center gap-3">
+                      <img src="images/logos/default_image.svg" />
+                      <p className="grow text-left">이선재</p>
+                      <Tag tagName="item">1/6</Tag>
+                    </li>
+                    <li className="flex items-center gap-3">
+                      <img src="images/logos/default_image.svg" />
+                      <p className="grow text-left">이현종</p>
+                      <Tag tagName="item">1/6</Tag>
+                    </li>
+                    <li className="flex items-center gap-3">
+                      <img src="images/logos/default_image.svg" />
+                      <p className="grow text-left">김건우</p>
+                      <Tag tagName="item">1/6</Tag>
+                    </li>
+                  </ul>
                 </div>
-              )} */}
+              </div>
+            )}
           </Modal>
         )}
       </div>

--- a/src/pages/detail/detail.tsx
+++ b/src/pages/detail/detail.tsx
@@ -26,14 +26,15 @@ const Detail = () => {
   const [viewPayment, setViewPayment] = useState(false);
 
   // counter 상태 관리
-  const [num, setNum] = useState(0);
+  // const [num, setNum] = useState(0);
 
   // modal 상태 관리
-  // 임시로 1, 2, 3으로 지정했고 추후에 상세페이지에서 버튼 클릭했을 때
-  // 정보를 받아서 모달 콘텐츠가 알맞게 나오게 하면 될 것 같습니다.
-  const [content, setContent] = useState(2);
+  // 상세페이지에서 버튼 클릭했을 때 정보를 받아서 모달 콘텐츠가 알맞게 나오게 하면 될 것 같습니다.
+  // 임시로 공구하기, 구매자 확인만 동작하게 만들었습니다.
+  const [content, setContent] = useState(typeBuy);
 
-  const handleModal = () => {
+  const handleModal = (contentType: string) => {
+    setContent(contentType);
     setViewPayment(true);
   };
 
@@ -110,7 +111,8 @@ const Detail = () => {
             text="text-sm"
             bg="main"
             color="white"
-            onClick={() => handleModal()}
+            // handleModal 변수에 따라서 모달 내용 변경되게
+            onClick={() => handleModal(typeBuy)}
           >
             공구하기
           </Button>
@@ -118,24 +120,24 @@ const Detail = () => {
         {viewPayment && (
           <Modal setViewPayment={setViewPayment}>
             {/* content에 입력된 정보에 따라서 modal 내용이 변경될 수 있게 */}
-            {/* content === 1 : 공구 */}
-
-            <div>
-              <h2 className="mb-5 font-semibold">
-                공구 장소, 시간을 확인하세요
-              </h2>
-              <div className="flex flex-col gap-4 mb-8">
-                <Tag tagName="location">공릉2동 주공아파트 3단지 놀이터 앞</Tag>
-                <Tag tagName="time">10:00</Tag>
-                <Tag tagName="people">2/10</Tag>
+            {content === typeBuy && (
+              <div>
+                <h2 className="mb-5 font-semibold">
+                  공구 장소, 시간을 확인하세요
+                </h2>
+                <div className="flex flex-col gap-4 mb-8">
+                  <Tag tagName="location">
+                    공릉2동 주공아파트 3단지 놀이터 앞
+                  </Tag>
+                  <Tag tagName="time">10:00</Tag>
+                  <Tag tagName="people">2/10</Tag>
+                </div>
+                <Button bg="main" color="white" height="40px" text="text-sm">
+                  공구하기
+                </Button>
               </div>
-              <Button bg="main" color="white" height="40px" text="text-sm">
-                공구하기
-              </Button>
-            </div>
-
-            {/* content === 2 : 구매 */}
-            {/* {content === 2 && (
+            )}
+            {/* {content === ??? && (
                 <div>
                   <h2 className="mb-5 font-semibold">
                     거래 가격, 장소, 개수를 확인하세요
@@ -156,37 +158,36 @@ const Detail = () => {
                 </div>
               )} */}
             {/* 구매자 늘어나면 스크롤 넣어야 될것 같습니다. */}
-            {/* content === 3 : 구매자 조회 */}
-            {/* {content === 3 && (
-                <div>
-                  <h2 className="mb-3">구매 신청자 목록</h2>
-                  <div className="flex flex-col gap-5">
-                    <Tag tagName="people">2/10</Tag>
-                    <ul className="mr-7 flex flex-col gap-3">
-                      <li className="flex items-center gap-3">
-                        <img src="images/logos/default_image.svg" />
-                        <p className="grow text-left">장유진</p>
-                        <Tag tagName="item">1/6</Tag>
-                      </li>
-                      <li className="flex items-center gap-3">
-                        <img src="images/logos/default_image.svg" />
-                        <p className="grow text-left">이선재</p>
-                        <Tag tagName="item">1/6</Tag>
-                      </li>
-                      <li className="flex items-center gap-3">
-                        <img src="images/logos/default_image.svg" />
-                        <p className="grow text-left">이현종</p>
-                        <Tag tagName="item">1/6</Tag>
-                      </li>
-                      <li className="flex items-center gap-3">
-                        <img src="images/logos/default_image.svg" />
-                        <p className="grow text-left">김건우</p>
-                        <Tag tagName="item">1/6</Tag>
-                      </li>
-                    </ul>
-                  </div>
+            {content === typeSell && (
+              <div>
+                <h2 className="mb-3">구매 신청자 목록</h2>
+                <div className="flex flex-col gap-5">
+                  <Tag tagName="people">2/10</Tag>
+                  <ul className="mr-7 flex flex-col gap-3">
+                    <li className="flex items-center gap-3">
+                      <img src="images/logos/default_image.svg" />
+                      <p className="grow text-left">장유진</p>
+                      <Tag tagName="item">1/6</Tag>
+                    </li>
+                    <li className="flex items-center gap-3">
+                      <img src="images/logos/default_image.svg" />
+                      <p className="grow text-left">이선재</p>
+                      <Tag tagName="item">1/6</Tag>
+                    </li>
+                    <li className="flex items-center gap-3">
+                      <img src="images/logos/default_image.svg" />
+                      <p className="grow text-left">이현종</p>
+                      <Tag tagName="item">1/6</Tag>
+                    </li>
+                    <li className="flex items-center gap-3">
+                      <img src="images/logos/default_image.svg" />
+                      <p className="grow text-left">김건우</p>
+                      <Tag tagName="item">1/6</Tag>
+                    </li>
+                  </ul>
                 </div>
-              )} */}
+              </div>
+            )}
           </Modal>
         )}
       </div>

--- a/src/pages/detail/detail.tsx
+++ b/src/pages/detail/detail.tsx
@@ -7,6 +7,8 @@ import PostType from '../../components/PostType';
 import Comment from '../../components/Comment';
 import CommentAdd from '../../components/CommentAdd';
 import Button from '../../components/Button';
+import Modal from '../../components/Modal';
+import Tag from '../../components/Tag';
 
 import close from '/images/icons/close.svg';
 import basicImage from '/images/chef/drawingChef.svg';
@@ -22,6 +24,21 @@ const Detail = () => {
   // 관심 및 댓글의 수
   const [interest, setInterest] = useState(7);
   const [commentNum, setCommentNum] = useState(5);
+
+  const [viewPayment, setViewPayment] = useState(false);
+
+  // counter 상태 관리
+  const [num, setNum] = useState(0);
+
+  // modal 상태 관리
+  // 임시로 1, 2, 3으로 지정했고 추후에 상세페이지에서 버튼 클릭했을 때
+  // 정보를 받아서 모달 콘텐츠가 알맞게 나오게 하면 될 것 같습니다.
+  const [content, setContent] = useState(2);
+
+  const handleModal = () => {
+    setViewPayment(true);
+  };
+
   return (
     <div className="pt-14 pb-[100px] h-screen">
       <Header>
@@ -91,10 +108,90 @@ const Detail = () => {
           </div>
           <Comment />
           <CommentAdd />
-          <Button height="40px" text="text-sm" bg="main" color="white">
+          <Button
+            height="40px"
+            text="text-sm"
+            bg="main"
+            color="white"
+            onClick={() => handleModal()}
+          >
             공구하기
           </Button>
         </div>
+        {viewPayment && (
+          <Modal setViewPayment={setViewPayment}>
+            {/* content에 입력된 정보에 따라서 modal 내용이 변경될 수 있게 */}
+            {/* content === 1 : 공구 */}
+
+            <div>
+              <h2 className="mb-5 font-semibold">
+                공구 장소, 시간을 확인하세요
+              </h2>
+              <div className="flex flex-col gap-4 mb-8">
+                <Tag tagName="location">공릉2동 주공아파트 3단지 놀이터 앞</Tag>
+                <Tag tagName="time">10:00</Tag>
+                <Tag tagName="people">2/10</Tag>
+              </div>
+              <Button bg="main" color="white" height="40px" text="text-sm">
+                공구하기
+              </Button>
+            </div>
+
+            {/* content === 2 : 구매 */}
+            {/* {content === 2 && (
+                <div>
+                  <h2 className="mb-5 font-semibold">
+                    거래 가격, 장소, 개수를 확인하세요
+                  </h2>
+                  <div className="flex flex-col gap-4 mb-8">
+                    <Tag tagName="cash">총가격 : 9,000원</Tag>
+                    <Tag tagName="location">
+                      공릉2동 주공아파트 3단지 놀이터 앞
+                    </Tag>
+                    <Tag tagName="item">
+                      구매 개수 <Counter num={num} setNum={setNum}></Counter>
+                    </Tag>
+                    <Tag tagName="time">10:00</Tag>
+                  </div>
+                  <Button bg="main" color="white" height="40px" text="text-sm">
+                    구매하기
+                  </Button>
+                </div>
+              )} */}
+            {/* 구매자 늘어나면 스크롤 넣어야 될것 같습니다. */}
+            {/* content === 3 : 구매자 조회 */}
+            {/* {content === 3 && (
+                <div>
+                  <h2 className="mb-3">구매 신청자 목록</h2>
+                  <div className="flex flex-col gap-5">
+                    <Tag tagName="people">2/10</Tag>
+                    <ul className="mr-7 flex flex-col gap-3">
+                      <li className="flex items-center gap-3">
+                        <img src="images/logos/default_image.svg" />
+                        <p className="grow text-left">장유진</p>
+                        <Tag tagName="item">1/6</Tag>
+                      </li>
+                      <li className="flex items-center gap-3">
+                        <img src="images/logos/default_image.svg" />
+                        <p className="grow text-left">이선재</p>
+                        <Tag tagName="item">1/6</Tag>
+                      </li>
+                      <li className="flex items-center gap-3">
+                        <img src="images/logos/default_image.svg" />
+                        <p className="grow text-left">이현종</p>
+                        <Tag tagName="item">1/6</Tag>
+                      </li>
+                      <li className="flex items-center gap-3">
+                        <img src="images/logos/default_image.svg" />
+                        <p className="grow text-left">김건우</p>
+                        <Tag tagName="item">1/6</Tag>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              )} */}
+          </Modal>
+        )}
       </div>
     </div>
   );

--- a/src/pages/detail/detail.tsx
+++ b/src/pages/detail/detail.tsx
@@ -15,8 +15,6 @@ import basicImage from '/images/chef/drawingChef.svg';
 import map from '/images/tag/location.svg';
 import time from '/images/tag/time.svg';
 import member from '/images/tag/member.svg';
-import Modal from '../../components/Modal';
-import Tag from '../../components/Tag';
 
 const Detail = () => {
   // 공구인지, 판매하기인지에 따라 멘트 구별


### PR DESCRIPTION
## 🔍 PR 유형 (Type of PR)

어떤 변경사항인지 체크해주세요 (중복 체크 가능):

- [X] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [X] 🎨 CSS 등 사용자 UI 디자인 변경
- [ ] 📝 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️ 코드 리팩토링
- [ ] 💬 주석 추가 및 수정
- [ ] 📄 문서 수정
- [ ] 🧪 테스트 추가, 테스트 리팩토링
- [ ] 📦 빌드 또는 패키지 매니저 수정
- [ ] 🗂️ 파일 혹은 폴더명 수정
- [ ] 🗑️ 파일 혹은 폴더 삭제

---

## 📝 PR 설명 (Description)

- 모달 내용 모달 컴포넌트가 아닌 페이지에서 작성해서 children으로 받을 수 있게
- 모달이 화면 전부 가리지 못해서 위치 잡는 방법 fixed로 변경
- 위에 따라서 모달창 닫는 버튼도 fixed로 위치 잡게 변경
- 데이터 받아오는것 따라서 modal 내용 다르게 출력 할 수 있게 만듬

---

## 📸 스크린샷 (Screenshots)

임시로 공구하기, 구매자 확인에 따라 화면 다르게 나오게 만들었습니다.

공구하기 화면일 때 모달
![modal-renewal1](https://github.com/user-attachments/assets/21e9dd4d-1d55-4d2e-966e-c4fdf93dfdce)

구매자 확인일 때 모달
![modal-renewal2](https://github.com/user-attachments/assets/09c318a9-cd70-4cfd-bd28-4be953ffd805)

---

## ✅ 체크리스트 (Checklist)

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 **컴파일**되고 모든 **테스트**를 통과했습니다.
- [x] 필요한 경우 **주석**을 작성했습니다.
- [x] 관련 **문서**를 업데이트했습니다.

---

