### PR TITLE
Bug[#248]: 상세 주소 전달 오류 해결

### DIFF
--- a/src/components/kakaoAddr.tsx
+++ b/src/components/kakaoAddr.tsx
@@ -56,10 +56,10 @@ const KakaoAddressSearch: React.FC<AddressProps> = ({
     }).open();
   };
 
-  const fullAddress = `${addr1} ${addr2}`;
-  setSubLocation(fullAddress);
-
+  // 상세 주소가 입력되면 fullAddress 상태 업데이트
   const handleSubmit = async () => {
+    const fullAddress = `${addr1} ${addr2}`;
+    setSubLocation(fullAddress);
     setAddress(subLocation);
   };
 

--- a/src/components/kakaoAddr.tsx
+++ b/src/components/kakaoAddr.tsx
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import React, { useState, useEffect } from 'react';
 
 interface AddressProps {
@@ -12,7 +11,7 @@ const KakaoAddressSearch: React.FC<AddressProps> = ({
 }) => {
   const [addr1, setAddr1] = useState(''); // 기본 주소 상태
   const [addr2, setAddr2] = useState(''); // 상세 주소 상태
-  const [address, setAddress] = useState('');
+  const [address, setAddress] = useState(''); // 상세 주소 출력
 
   // 카카오 주소 검색 스크립트 로드
   useEffect(() => {
@@ -62,16 +61,6 @@ const KakaoAddressSearch: React.FC<AddressProps> = ({
 
   const handleSubmit = async () => {
     setAddress(subLocation);
-    // console.log('서버로 전송할 주소:', fullAddress);
-
-    // try {
-    //   const response = await axios.post('/seller/products', {
-    //     address: fullAddress,
-    //   });
-    //   console.log('서버 응답:', response.data);
-    // } catch (error) {
-    //   console.error('서버 요청 중 오류 발생:', error);
-    // }
   };
 
   return (

--- a/src/components/kakaoAddr.tsx
+++ b/src/components/kakaoAddr.tsx
@@ -1,9 +1,18 @@
 import axios from 'axios';
 import React, { useState, useEffect } from 'react';
 
-const KakaoAddressSearch: React.FC = () => {
+interface AddressProps {
+  subLocation: string;
+  setSubLocation: (addres: string) => void;
+}
+
+const KakaoAddressSearch: React.FC<AddressProps> = ({
+  subLocation,
+  setSubLocation,
+}) => {
   const [addr1, setAddr1] = useState(''); // 기본 주소 상태
   const [addr2, setAddr2] = useState(''); // 상세 주소 상태
+  const [address, setAddress] = useState('');
 
   // 카카오 주소 검색 스크립트 로드
   useEffect(() => {
@@ -11,6 +20,7 @@ const KakaoAddressSearch: React.FC = () => {
     script.src =
       '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
     script.async = true;
+
     document.head.appendChild(script);
   }, []);
 
@@ -47,18 +57,21 @@ const KakaoAddressSearch: React.FC = () => {
     }).open();
   };
 
-  const handleSubmit = async () => {
-    const fullAddress = `${addr1} ${addr2}`;
-    console.log('서버로 전송할 주소:', fullAddress);
+  const fullAddress = `${addr1} ${addr2}`;
+  setSubLocation(fullAddress);
 
-    try {
-      const response = await axios.post('/seller/products', {
-        address: fullAddress,
-      });
-      console.log('서버 응답:', response.data);
-    } catch (error) {
-      console.error('서버 요청 중 오류 발생:', error);
-    }
+  const handleSubmit = async () => {
+    setAddress(subLocation);
+    // console.log('서버로 전송할 주소:', fullAddress);
+
+    // try {
+    //   const response = await axios.post('/seller/products', {
+    //     address: fullAddress,
+    //   });
+    //   console.log('서버 응답:', response.data);
+    // } catch (error) {
+    //   console.error('서버 요청 중 오류 발생:', error);
+    // }
   };
 
   return (
@@ -101,6 +114,7 @@ const KakaoAddressSearch: React.FC = () => {
           확인
         </button>
       </div>
+      <p className="subLocation">{address}</p>
     </div>
   );
 };

--- a/src/pages/write/write.tsx
+++ b/src/pages/write/write.tsx
@@ -399,7 +399,7 @@ const Write = () => {
 
               <div className="info-location-detail">
                 <div className="flex gap-[22px] py-[7px] mb-[7px] border-b">
-                  <p className="font-semibold">판매 상세 위치 </p>
+                  <p className="font-semibold">상세 위치 </p>
                   <KakaoAddressSearch
                     subLocation={subLocation}
                     setSubLocation={(address) => setSubLocation(address)}

--- a/src/pages/write/write.tsx
+++ b/src/pages/write/write.tsx
@@ -58,6 +58,8 @@ const Write = () => {
 
   const [selectDate, setSelectDate] = useState<Dayjs | null>(null);
 
+  const [subLocation, setSubLocation] = useState('');
+
   const [uploadImg, setUploadImg] = useState<{ path: string; name: string }[]>(
     [],
   );
@@ -107,6 +109,7 @@ const Write = () => {
     // 전송 값이 input이 아닌 경우 추가
     data.quantity = num;
     data.extra.location = location;
+    data.extra.subLocation = subLocation;
     data.extra.type = productsType;
 
     // 가격 정수 형태로 변경 후 전송
@@ -270,8 +273,11 @@ const Write = () => {
 
               <div className="info-location-detail">
                 <div className="flex gap-[22px] py-[7px] mb-[7px] border-b">
-                  <p className="font-semibold">공구 상세 위치 </p>
-                  <KakaoAddressSearch />
+                  <p className="font-semibold w-[60px]">상세 위치 </p>
+                  <KakaoAddressSearch
+                    subLocation={subLocation}
+                    setSubLocation={(address) => setSubLocation(address)}
+                  />
                 </div>
                 {errors.extra?.subLocation && (
                   <Error>{errors.extra.subLocation?.message}</Error>
@@ -394,7 +400,10 @@ const Write = () => {
               <div className="info-location-detail">
                 <div className="flex gap-[22px] py-[7px] mb-[7px] border-b">
                   <p className="font-semibold">판매 상세 위치 </p>
-                  <KakaoAddressSearch />
+                  <KakaoAddressSearch
+                    subLocation={subLocation}
+                    setSubLocation={(address) => setSubLocation(address)}
+                  />
                 </div>
                 {errors.extra?.subLocation && (
                   <Error>{errors.extra.subLocation?.message}</Error>


### PR DESCRIPTION
## 🔍 PR 유형 (Type of PR)

어떤 변경사항인지 체크해주세요 (중복 체크 가능):

- [x] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [x] 🎨 CSS 등 사용자 UI 디자인 변경
- [ ] 📝 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️ 코드 리팩토링
- [ ] 💬 주석 추가 및 수정
- [ ] 📄 문서 수정
- [ ] 🧪 테스트 추가, 테스트 리팩토링
- [ ] 📦 빌드 또는 패키지 매니저 수정
- [ ] 🗂️ 파일 혹은 폴더명 수정
- [ ] 🗑️ 파일 혹은 폴더 삭제

---

## 📝 PR 설명 (Description)

- 상세주소 컴포넌트에서 바로 서버에 보내던 것 props로 보내는 것으로 변경
- 글 작성 페이지에서 props 받아서 서버로 전달
- 주소 검색 창에 맞춰서 이름 '공구 상세 위치' => '상세 위치' 변경
- 주소 검색 창 하단에 상세 주소 출력

---

## 📸 스크린샷 (Screenshots)

![메인페이지 주소 정상](https://github.com/user-attachments/assets/29b20671-5845-4012-a567-097073fbb1a0)
![상세 위치 주소](https://github.com/user-attachments/assets/51252024-f822-4e76-8050-42b8fef2f746)
![상세페이지 주소 정상](https://github.com/user-attachments/assets/109e1ad4-02ce-4df9-aebd-fc152eb3d3df)


---

## ✅ 체크리스트 (Checklist)

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 **컴파일**되고 모든 **테스트**를 통과했습니다.
- [x] 필요한 경우 **주석**을 작성했습니다.
- [ ] 관련 **문서**를 업데이트했습니다.

---

## 🛠 추가 정보 (Additional Information)

- any를 다른 타입으로 하라는 오류는 못 잡겠...
